### PR TITLE
Fix href to connector-codegen in README.md.

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -192,5 +192,5 @@ This source code generator uses:
 [connector-typescript]: https://github.com/datafoodconsortium/connector-typescript
 [connector-ruby]: https://github.com/datafoodconsortium/connector-ruby
 [connector-php]: https://github.com/datafoodconsortium/connector-php
-[connector-codegen]: https://github.com/datafoodconsortium/connector-cedegen
+[connector-codegen]: https://github.com/datafoodconsortium/connector-codegen
 [data-model-uml]: https://github.com/datafoodconsortium/data-model-uml


### PR DESCRIPTION
This is such a tiny typo, but seemed to be in a critical place.

While I was at it, I ran https://github.com/datafoodconsortium through deadlinkchecker.com, and there are a few others, mostly for discussion tabs that haven't been created in that respective repository, as well as one for the prototype and one that's just a GItHub internal.

|    Status     | URL       | Source link text                                                     |
| ------------- | :-------- | :------------------------------------------------------------------- |
| -1  | https://proto.datafoodconsortium.org/                       | proto.datafoodconsortium.org |
| 404 | https://github.com/datafoodconsortium/connector-typescript/discussions | discussions       |
| 404 | https://github.com/datafoodconsortium/connector-cedegen                | connector-codegen |
| 404 | https://github.com/search/feedback                                     | form/action(post) |
| 404 | https://github.com/datafoodconsortium/prototype/discussions            | discussions       |
| 404 | https://github.com/datafoodconsortium/business-api/discussions         | discussions       |
