### PR TITLE
Move Tech Project's meeting notes hither from the `standard` repo

### DIFF
--- a/meetings/2024/2024-06-03.md
+++ b/meetings/2024/2024-06-03.md
@@ -1,0 +1,33 @@
+## Agenda
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/1
+- Where do we take our notes?
+- DFC WebId (https://github.com/datafoodconsortium/standard/issues/10)
+- Modularizing our ontology and version control
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) : we need to contribute to this discussion : https://github.com/orgs/datafoodconsortium/discussions/35
+- Define next meeting date: 17.06.2024 4PM CET
+
+## Participants
+
+- @lecoplibre
+- @RachL
+- @RaggedStaff
+- @simonLouvet
+
+## Decision on note taking
+
+Notes are still useful for:
+- listing issues to create => for this we agreed to use draft issue mode
+- publish / be transparent on which topic people talked
+- track participants / progress
+- future meeting dates: for this we agree to mimic https://github.com/orgs/solid/projects/16/views/1
+
+Rachel will create a file for notes in the standard repository and create a view in the tech project to see next meeting dates. 
+
+Currently notes are tracking decisions but not meetings minutes. Meeting minutes are usueful to understand why we do things, but need a lot of time / effort and are harder to read. We agreed to keep our current format (summary only), but need to be aware to document a lot more our decisions.
+
+## Modularizing our ontology and version control
+
+These topics are with ontology circle for now. First step is to define next version content: from there we need to check if we need a dedicated module and how we maitain versions.
+
+This project was mentioned https://github.com/Wimmics/olivaw (an agile methodology to develop modular ontologies)
+

--- a/meetings/2024/2024-06-17.md
+++ b/meetings/2024/2024-06-17.md
@@ -1,0 +1,48 @@
+## Agenda
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/1
+- Beckn protocol
+- Data Capture
+- W3id
+- WebID
+- Modularizing our ontology and version control: update from the ontology circle
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) : we need to contribute to this discussion : https://github.com/orgs/datafoodconsortium/discussions/35
+- Define next meeting date: 01.07.2024 4PM CET
+
+## Participants
+
+- @RachL
+- @RaggedStaff
+- @lecoqlibre
+- @jgaehring
+
+## Beckn protocol
+
+This protocol is widely used in India (backed by the Indian government). We don't know if we can easily integrate with it. Benoit from Startin'blox is going to do a first analysis. 
+Once this is done, we will define the next steps. For now, this is recorded in a draft issue here: https://github.com/orgs/datafoodconsortium/projects/5/views/1?pane=issue&itemId=67692136
+Useful links: 
+- https://becknprotocol.io/
+- https://github.com/beckn
+- https://developers.becknprotocol.io/docs/introduction/the-registry-infrastructure/
+
+## Data Capture
+
+This is funded by FDC on a separate budget. Issue to track progress is here: https://github.com/datafoodconsortium/.github/issues/36
+
+## W3id (https://github.com/datafoodconsortium/standard/issues/18)
+
+Garethe didn't have a chance yet to test with his Apache server, which he needs to set up first. If this isn't working, Garethe will ask Simon if he has a server available to test.
+
+## WebID (https://github.com/datafoodconsortium/standard/issues/10)
+
+Maxime has already spend 2 days on this (which was the budget allocated so far). 
+To go from the current draft version in the issue to implementation in the standard, the task is quite massive. Introducing WebID is indeed impacting the standard everywhere. 
+The standard needs to be reorganized and especially be more pratical for platforms (with real use cases).
+
+Maxime has started working on the standard v2 here: https://datafoodconsortium.gitbook.io/dfc-standard-v2/client-protocols/enterprisehttps://datafoodconsortium.gitbook.io/dfc-standard-v2/client-protocols/enterprise
+
+We agreed the next step is for Garethe to use part of his budget for documentation to document use cases on a different branch Maxime is working on. This way, everyone will work with the same use cases. Issue is https://github.com/datafoodconsortium/standard/issues/29
+In parallel, we need to find budget to continue work on v2 / WebID implementation. Maxime might continue working anyway as he needs this for his own platform, Mycelium.
+
+## Modularizing ontology and version control
+
+This topic has not progressed in ontology circle yet

--- a/meetings/2024/2024-07-01.md
+++ b/meetings/2024/2024-07-01.md
@@ -1,0 +1,63 @@
+## Agenda
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/1
+- Beckn protocol
+- W3id
+- Modularizing our ontology and version control: update from the ontology circle
+- WebID
+- New domain name and OVH account for the international org
+- Data Capture
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) : we need to contribute to this discussion : https://github.com/orgs/datafoodconsortium/discussions/35
+- Shipping option - Simon
+- Define next meeting date: 15.07.2024 4PM CET
+
+## Participants
+
+- @RachL
+- @RaggedStaff
+- @lecoqlibre
+- @jgaehring
+- @simonLouvet
+
+## Beckn protocol
+
+Garethe might ping Benoit from Startin' blox to see where they are at
+
+## W3id  (https://github.com/datafoodconsortium/standard/issues/18)
+
+Garethe has ordered a new service at infomaniak and will test this on an apache server soon
+
+## Htaccess rules / Modularizing ontology and version control
+
+It looks like, for maintenance purposes, we need to have URL access for all releases, not only the latest one.
+
+We also agree to only put version number on context files, not on all files.
+
+Ontology releases vs taxonomies releases: we need to introduce some kind of dependency system between the two. E.g. we introduced new taxonomies, so this is a breaking change. 
+Our release notes will need to reflect the link between the two versioning system.
+
+⚠️Github is doing a redirect on /latest, this means we need to test this behavior: https://github.com/datafoodconsortium/standard/issues/32
+
+Modularizing: this topic has not progressed in ontology circle yet
+
+## New domain names and OVH account for the international org
+
+As a reminder, we are taking a new domain to avoid using the FR org domain, and we don't brainstorm about a real new name yet, see https://github.com/orgs/datafoodconsortium/discussions/20
+
+Tasks to perform:
+- Create a new OVH account and give access to international admins https://github.com/datafoodconsortium/standard/issues/33
+- Create a dfc-standard.org domain name https://github.com/datafoodconsortium/standard/issues/34
+- Move the VocBench and ShowVoc instances on the international OVH account (easier for accounting purposes to have all paid server on the same hosting account https://github.com/datafoodconsortium/standard/issues/35
+
+## Data Capture (https://github.com/datafoodconsortium/.github/issues/36)
+
+Jamie will do an update next time
+
+## WebID (https://github.com/datafoodconsortium/standard/issues/10)
+
+Maxime is still working on it. He works at the same time on the new connector/semantizer to test the new standard version. Plan is to make a demo that displays the catalogs of the passed in user, enterprise or platform WebId.
+
+## Releases and Shipping option
+
+We did not have time for these topics: Simon and Garethe will solve shipping option async see https://datafoodconsortium.slack.com/archives/C020KLNTDF0/p1719489678423519
+
+For releases, this was more a reminder that everyone should contribute here: https://github.com/orgs/datafoodconsortium/discussions/35

--- a/meetings/2024/2024-07-15.md
+++ b/meetings/2024/2024-07-15.md
@@ -1,0 +1,49 @@
+## Agenda
+
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/
+- W3id
+- Data Capture
+- Pagination of endpoints
+- Modularizing our ontology and version control: update from the ontology circle
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) - we need to contribute to this discussion: https://github.com/orgs/datafoodconsortium/discussions/35  
+- Define next meeting date: 29.07.2024 4 PM CET
+
+## Participants
+
+- @RachL
+- @RaggedStaff
+- @jgaehring
+- @simonLouvet
+
+## Documenting order states (https://github.com/datafoodconsortium/standard/issues/16)
+
+This is the first step towards more pratical documentation for platforms who wishes to implement the standard. This isn't the standard (as the DFC states are documented as a SKOS vocabulary). This is only intended to go on gitbook.
+We need a second validation on the linked PR to be able to merge this work.
+
+## New OVH account (https://github.com/datafoodconsortium/standard/issues/33)
+
+This isn't closed as we need to find a way to share the password. We have not decided during the meeting, this is still open for action / decision.
+
+New email address is up and running, therefore we are closing https://github.com/datafoodconsortium/standard/issues/34 and created a new issue for the second email (which we will do only if needed).
+
+## Data capture
+
+Update here: https://github.com/datafoodconsortium/connector-codegen/issues/24#issuecomment-2228639516 Garethe will try to unblock point 2
+
+## W3id (https://github.com/datafoodconsortium/standard/issues/18)
+
+This is not possible has planned, and Simon won't have the time to setup and maintain a dedicated server in the short term. Garethe is proposing again the following strategy:
+- 1 branch per version number
+- through github pages
+
+It's not as clear as releases and it has the downside of creating many branches / which can look messy. An archiving strategy might be needed.
+
+Action for Garethe: check with Maxime if there were any other downside, otherwise both Simon and Garethe agree they can live with this solution.
+
+## Pagination of endpoints
+
+This will need to be added to the standard but there is no budget to work on this currently (it does not only need documentation but also work on the serializer). UK team will follow Shopify's GraphQL-based pagination strategy to unblock the pilot project.
+
+## Modularizing our ontology and version control + release strategy
+
+These topics were not discuss but only reminded.

--- a/meetings/2024/2024-07-29.md
+++ b/meetings/2024/2024-07-29.md
@@ -1,0 +1,54 @@
+## Agenda
+
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/
+- NGI Search application
+- UML Model Updates - is this process documented?
+- Define next meeting date: 09.09.2024 4pm CET
+
+**Reminders**
+
+- Modularizing our ontology and version control: update from the ontology circle
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) - we need to contribute to this discussion: https://github.com/orgs/datafoodconsortium/discussions/35
+
+## Participants
+
+- @RaggedStaff
+- @jgaehring
+- @lecoqlibre
+- @RachL
+
+## Order's states documentation (https://github.com/datafoodconsortium/standard/issues/16)
+
+Maxime is going to add a second review to unblock Garethe. PR is here: https://github.com/datafoodconsortium/standard/issues/16.
+
+## WebID and profile (https://github.com/datafoodconsortium/standard/issues/10)
+
+Maxime did a demo that showed the usage of the Semantizer library to query and display the catalogs owned by a WebId (Person). This implementation follows the fisrt version of the client-to-client protocol.
+
+## Data Capture ( https://github.com/datafoodconsortium/connector-codegen/issues/24)
+
+A sample / mockup or even just a document would help Jamie to understand how mixins will work in the typescript semantizer. Maxime gave a link to how it is implemented so far: https://github.com/assemblee-virtuelle/semantizer-typescript/blob/61c5ddbcde51fbc7469ac315169ac8b42a74d194/src/test/src/index.ts.
+Garethe and Jamie will meet this week to unblock point 2, see https://github.com/datafoodconsortium/connector-codegen/issues/24#issuecomment-2228639516.
+
+## Refresh tokens (https://github.com/datafoodconsortium/standard/issues/39)
+
+Garethe will move forward on implementation.
+
+## Global email address (https://github.com/datafoodconsortium/standard/issues/36)
+
+We agreed with Garethe's proposal of switching main address to hello@dfc-standard.org
+
+## NGI Search application
+
+Maxime worked on a proposal, but it must be submited before 5PM CET today and there are elements missing (team + ressources).
+
+Maxime and Rachel will meet after the meeting to finalize.
+
+## UML Model Updates (https://github.com/datafoodconsortium/standard/issues/41)
+
+This process is documented in the [connector-codegen repo](https://github.com/datafoodconsortium/connector-codegen).
+Maxime is using Eclipse to visualize the UML. Garethe will try this out.
+The following project can be used as an example to follow to work collaboratively on the development of an ontology: https://github.com/Wimmics/olivaw.
+
+
+

--- a/meetings/2024/2024-09-09.md
+++ b/meetings/2024/2024-09-09.md
@@ -1,0 +1,45 @@
+## Agenda
+
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/
+- WebID and discovery discovery - Maxime's demo
+- Nicolas - Devops / dev support
+- Define next meeting date: 24.09.2024 4pm CET
+
+## Reminders
+
+- Modularizing our ontology and version control: update from the ontology circle
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) - we need to contribute to this discussion: https://github.com/orgs/datafoodconsortium/discussions/35
+
+## Participants
+
+- @RaggedStaff
+- @simonLouvet
+- @jgaehring
+- @lecoqlibre
+- @RachL
+
+## Next meeting date
+
+Garethe is no longer available on Monday's, so proposal is to shift to Tuesday's, same time.
+
+## Typescript's connector testing strategy (https://github.com/datafoodconsortium/connector-typescript/issues/13)
+
+Everyone is invited to have a look at Jamie's comment [here](https://github.com/datafoodconsortium/connector-typescript/issues/13#issuecomment-2326843343) so we can close the issue next meeting.
+
+## Data discovery (https://github.com/datafoodconsortium/connector-codegen/issues/24)
+
+Garethe & Jamie will pair end of this week to get this kicked off.
+
+## Nicolas - Devops/dev support
+Prototype: Nicolas can help if a design is made (architecture, screens). A design would help to share the tasks with Simon.
+
+DevOps: ShowVoc & VocBench should be updated and synced. Maybe some GitHub actions can be set up, especially to check that the generated files from VocBench are clean. Nicolas told Maxime he is also working on Python scripts to check automatically some files before they are pushed on Git (on the local machine).
+
+Before confirming to Nicolas, we need to check how much budget is left on the FDC / DFC partnership
+
+## WebID & discovery - Maxime's demo Semantizer an a React-Admin app (https://github.com/datafoodconsortium/standard/issues/10)
+RDF datasets have been implemented in the new Semantizer version (2) on the "dataset" branch. Semantizer is based on the RDFJS interfaces and use mixins. Users can define their own mixins very easily to add methods to manipulate their data.
+
+The React-Admin app can list the catalogs of the producer. They are fetched from its WebId. We can see in the network console of the browser that the app is fetching my WebId, then the extended profile, then the enterprise and its extended profile where it finds links to the catalogs. On the interface of the app, we can see the list of catalogs of the producer. We can click on a catalog to see the contained catalog-items.
+
+In the code it is really simple, we load the documents (datasets) in the order explained above. Mixin are very easy to define. It is just a mixin function in TS in which you define some methods you want to add to your dataset. You also have to export a factory to create and load instances of your mixin (an helper is available).

--- a/meetings/2024/2024-09-24.md
+++ b/meetings/2024/2024-09-24.md
@@ -24,11 +24,11 @@ Two PR need review and were added to the board by Garethe:
 
 https://github.com/datafoodconsortium/connector-codegen/pull/20 and https://github.com/datafoodconsortium/connector-codegen/pull/23
 
-These PR are based on the old and unstable version of the connector and semantizer. A new version of the semantizer will be release on September 29th.
+These PR are based on the old and unstable version of the semantizer. A new version of the semantizer will be released at the end of September.
 We could base all current work on it but that would mean that platforms would need to update their version, which does not work with FDC roadmap which needs data capture to work in production before the end of the year.
 
 Rachel will create an issue to track this
-Maxime will list everything that might change / breck things to understand how big the changes are
+Maxime will list everything that might change / breck things to understand how big the changes are.
 
 Here are some notes I copy/pasted from the pad please edit if unrelevant:
 
@@ -42,6 +42,8 @@ That "wrapper" can be moved lower down the stack to the internals of the semanti
 
 We are not ready to participate this year (no good first issue to welcome contirbutors with / no time to review code). But we need to keep it in mind for next year. More info on the event: https://hacktoberfest.com/ 
 
-## Semantic streams
+## Using streams in Semantizer
 
-There is pending question from Maxime on whether streams can be used from the browser or should only locally? (sorry I'm not sure of my notes here)
+There is pending question from Maxime on what streams implementation to use. If we use the one from Node, we'll need a blundler to export browser packages. Otherwise we can use packages from npm but this would add an extra dependancy when using the library in a Node environment.
+
+Also the Stream interface in @rdfjs/types does not include a pipe method which is required in Semantizer.

--- a/meetings/2024/2024-09-24.md
+++ b/meetings/2024/2024-09-24.md
@@ -1,0 +1,47 @@
+## Agenda
+- Review Actions from last meeting see also https://github.com/orgs/datafoodconsortium/projects/5/views/
+- Semantizer / streams
+- Data capture
+- Connector codegen PR's
+- Hacktoberfest?
+- Define next meeting date: 08.10.2024 4pm CET
+
+## Reminders
+
+- Modularizing our ontology and version control: update from the ontology circle
+- Releases: Do we want a release schedule (e.g. 1 major per year, 1 minor per month) - we need to contribute to this discussion: https://github.com/orgs/datafoodconsortium/discussions/35
+
+## Participants
+
+- @RaggedStaff
+- @jgaehring
+- @lecoqlibre
+- @RachL
+
+## Connector codegen PR's and Data capture 
+
+Two PR need review and were added to the board by Garethe:
+
+https://github.com/datafoodconsortium/connector-codegen/pull/20 and https://github.com/datafoodconsortium/connector-codegen/pull/23
+
+These PR are based on the old and unstable version of the connector and semantizer. A new version of the semantizer will be release on September 29th.
+We could base all current work on it but that would mean that platforms would need to update their version, which does not work with FDC roadmap which needs data capture to work in production before the end of the year.
+
+Rachel will create an issue to track this
+Maxime will list everything that might change / breck things to understand how big the changes are
+
+Here are some notes I copy/pasted from the pad please edit if unrelevant:
+
+Relevant part of the TypeScript codegen implementation (pending merge of PR #20) where the call to semantizer's `.export()` method will be wrapped with the Data Capture logic that calls `.export()` again with the new destination:
+
+https://github.com/jgaehring/connector-codegen/blob/2c8507af85919862669ef8a989bb2679f553dc78/src/org/datafoodconsortium/connector/codegen/typescript/static/src/Connector.ts#L182-L188
+
+That "wrapper" can be moved lower down the stack to the internals of the semantizer 2.0 once it is released and ready.
+
+## Hacktoberfest
+
+We are not ready to participate this year (no good first issue to welcome contirbutors with / no time to review code). But we need to keep it in mind for next year. More info on the event: https://hacktoberfest.com/ 
+
+## Semantic streams
+
+There is pending question from Maxime on whether streams can be used from the browser or should only locally? (sorry I'm not sure of my notes here)

--- a/meetings/2024/test.md
+++ b/meetings/2024/test.md
@@ -1,0 +1,2 @@
+# Test
+this is a test


### PR DESCRIPTION
This merges all but today's latest meeting, which @RachL will add later this evening. If this can be merged before then, then it should make it pretty easy to integrate today's notes into the existing directory/file structure. 

The rationale for this is twofold, based my original comment on https://github.com/datafoodconsortium/standard/issues/46#issuecomment-2393971354:
- Moving these notes to the `.github` repository would avoid the branch protections required by the `standard` repository. These notes are also not strictly relevant to the DFC Standard itself, and would be more appropriately housed alongside our [community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories) and [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).
- A persistent branch, such as `projects/tech-meetings`, could be stably linked back to in the [Tech Meetings Project Board](https://github.com/orgs/datafoodconsortium/projects/5/views/2), rather than pointing to the `main` or `master` branch; that way branch protections can be fine-tuned or entirely removed regardless of which repository the notes are in. I'm using the example `projects/tech-meetings` here with [slash branches](https://www.baeldung.com/ops/git-refs-branch-slash-name) as a prefix category (potentially w/ branches `projects/main` and `projects/prototype` added now or later), but that's not necessary. Using a "feature branch" workflow also allows us to maintain a review process prior to merging, where others can commit additional notes,  add comments, link to relevant issues or PRs on GitHub, etc.

I still can't push directly to the `projects/tech-meetings` at this remote, but that should not be a problem for @RachL when creating a new file from the GitHub GUI. To illustrate, below are those steps and what they would look like, although from `datafoodconsortium/.github` rather than `jgaehring/.github`. Hopefully it does not differ drastically from your current workflow.

1. From your browser, go to the `.github` repository and make sure you're viewing the branch [`projects/tech-meetings`](https://github.com/datafoodconsortium/.github/tree/projects/tech-meetings), which can be toggled from any directory in the repo:
  
  ![Screenshot from 2024-10-08 11-20-45](https://github.com/user-attachments/assets/6614fd48-975c-4ef6-831a-36c662394c0e)
  
2. Now when you select "Add File" > "Create New File", it will open the GUI to write and commit directly to the `projects/tech-meetings` branch:
  
![image](https://github.com/user-attachments/assets/946d1de7-33c3-4aae-9cca-793db0b9ecdf)
  
3. You can then open a pull request against the `main` branch and select reviewers as needed:
![image](https://github.com/user-attachments/assets/2cb69ee0-42ff-48bf-ab70-b7e4988abb21)

And that should be it! Or did I miss something?
